### PR TITLE
Fix signed integers in exponents beginning with 0.

### DIFF
--- a/runtests.hs
+++ b/runtests.hs
@@ -64,6 +64,7 @@ testSuite = testGroup "Parser"
     , testCase "LiteralDecimal13"  (testLiteral "1e18"     "Right (JSDecimal \"1e18\")")
     , testCase "LiteralDecimal14"  (testLiteral "1e+18"    "Right (JSDecimal \"1e+18\")")
     , testCase "LiteralDecimal15"  (testLiteral "1e-18"    "Right (JSDecimal \"1e-18\")")
+    , testCase "LiteralDecimal16"  (testLiteral "1E-01"    "Right (JSDecimal \"1E-01\")")
 
     , testCase "LiteralString1"    (testLiteral "\"hello\\nworld\"" "Right (JSStringLiteral '\"' \"hello\\\\nworld\")")
     , testCase "LiteralString2"    (testLiteral "'hello\\nworld'"  "Right (JSStringLiteral '\\'' \"hello\\\\nworld\")")

--- a/src-dev/Language/JavaScript/Parser/Lexer.x
+++ b/src-dev/Language/JavaScript/Parser/Lexer.x
@@ -238,11 +238,11 @@ tokens :-
 --     | "0"
 --     | "0." $digit+                    { mkString decimalToken }
 
-<reg,divide> "0"              "." $digit* ("e"|"E") ("+"|"-")? $non_zero_digit+ $digit*
-    | $non_zero_digit $digit* "." $digit* ("e"|"E") ("+"|"-")? $non_zero_digit+ $digit*
-    |                "." $digit+          ("e"|"E") ("+"|"-")? $non_zero_digit+ $digit*
-    |        "0"                          ("e"|"E") ("+"|"-")? $non_zero_digit+ $digit*
-    | $non_zero_digit $digit*             ("e"|"E") ("+"|"-")? $non_zero_digit+ $digit*
+<reg,divide> "0"              "." $digit* ("e"|"E") ("+"|"-")? $digit+
+    | $non_zero_digit $digit* "." $digit* ("e"|"E") ("+"|"-")? $digit+
+    |                "." $digit+          ("e"|"E") ("+"|"-")? $digit+
+    |        "0"                          ("e"|"E") ("+"|"-")? $digit+
+    | $non_zero_digit $digit*             ("e"|"E") ("+"|"-")? $digit+
 -- ++FOO++
     |        "0"              "." $digit*
     | $non_zero_digit $digit* "." $digit*


### PR DESCRIPTION
I don't really know if this behaviour is according to the standard, but all other parsers I tested seem to accept it and parse it as integer, and not octal (as the leading zero might suggest, but that made me do pull request #12).
