### PR TITLE
Remove hs-source-dirs from test suite

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -72,8 +72,7 @@ Test-Suite test-language-javascript
                  , blaze-builder    >= 0.2     && < 1
                  -- need our own library for tests
                  , language-javascript >= 0.5.5
-  hs-source-dirs: . src ./dist/build
-
+  
 
 source-repository head
   type:     git


### PR DESCRIPTION
Otherwise the previously compiled library and the source files mix up, causing the test suite to not compile with this error message:

```
[ 8 of 11] Compiling Language.JavaScript.Parser.Parser ( src/Language/JavaScript/Parser/Parser.hs, dist-ghc/build/test-language-javascript/test-language-javascript-tmp/Language/JavaScript/Parser/Parser.o )

src/Language/JavaScript/Parser/Parser.hs:28:38:
    Couldn't match expected type `Alex AST.JSNode'
                with actual type `language-javascript-0.5.6:Language.JavaScript.Parser.Lexer.Alex
                                    Language.JavaScript.Parser.AST.JSNode'
    In the second argument of `runAlex', namely `parseProgram'
    In the expression: runAlex input parseProgram
    In an equation for `parse':
        parse input _srcName = runAlex input parseProgram
make: *** [build-ghc-stamp] Error 1
```
