### PR TITLE
newer alex and happy are needed with GHC 7.8

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -37,7 +37,10 @@ Library
                    , blaze-builder    >= 0.2     && < 1
                    , bytestring       >= 0.9.1   && < 1
                    , utf8-string      >= 0.3.7   && < 1
-  build-tools:       happy >= 1.18.5, alex >= 3.0.5
+  if impl(ghc >= 7.8)
+    build-tools:       happy >= 1.19, alex >= 3.1
+  else
+    build-tools:       happy >= 1.18.5, alex >= 3.0.5
   hs-source-dirs: src
   Exposed-modules:     Language.JavaScript.Parser
                        Language.JavaScript.Parser.Parser
@@ -51,7 +54,6 @@ Library
                        Language.JavaScript.Parser.ParserMonad
                        Language.JavaScript.Parser.StringEscape
                        Language.JavaScript.Parser.Token
-  Build-tools:         happy
   ghc-options:         -Wall
 
 Test-Suite test-language-javascript


### PR DESCRIPTION
Installing with GHC 7.8 will now give a more useful error message
when alex or happy are not new enough.
