### PR TITLE
Fix the build on GHC 7.10 and below

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -5,7 +5,6 @@ Description:         Parses Javascript into an Abstract Syntax Tree (AST).  Init
                      .
                      Note: Version 0.5.0 breaks compatibility with prior versions, the AST has been reworked to allow
                      round trip processing of JavaScript.
-Homepage:            https://github.com/erikd/language-javascript
 License:             BSD3
 License-file:        LICENSE
 Author:              Alan Zimmerman

--- a/src/Language/JavaScript/Parser/Lexer.x
+++ b/src/Language/JavaScript/Parser/Lexer.x
@@ -1,8 +1,13 @@
 {
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
+
+#if __GLASGOW_HASKELL__ >= 800
 -- Alex generates code with these warnings so we'll just ignore them.
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+#endif
+
 module Language.JavaScript.Parser.Lexer
     ( Token (..)
     , Alex


### PR DESCRIPTION
GHC doesn't know about these warning flags below GHC 8, so use CPP
to only have them at or after 8

This builds at least as far back as 7.0 for me