### PR TITLE
Add support for ES module import statements

### DIFF
--- a/src/Language/JavaScript/Parser/Lexer.x
+++ b/src/Language/JavaScript/Parser/Lexer.x
@@ -525,7 +525,9 @@ keywordNames =
     , ( "finally", FinallyToken )
     , ( "for", ForToken )
     , ( "function", FunctionToken )
+    , ( "from", FromToken )
     , ( "if", IfToken )
+    , ( "import", ImportToken )
     , ( "in", InToken )
     , ( "instanceof", InstanceofToken )
     , ( "let", LetToken )
@@ -566,8 +568,6 @@ keywordNames =
     -- ( "const",   FutureToken ) **** an actual token, used in productions
     -- enum                    **** an actual token, used in productions
     , ( "extends",  FutureToken )
-
-    , ( "import",   FutureToken )
     , ( "super",    FutureToken )
 
 

--- a/src/Language/JavaScript/Parser/Token.hs
+++ b/src/Language/JavaScript/Parser/Token.hs
@@ -73,6 +73,7 @@ data Token
     | FinallyToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | ForToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | FunctionToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
+    | FromToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | IfToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | InToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | InstanceofToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
@@ -88,6 +89,7 @@ data Token
     | VarToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | VoidToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | WhileToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
+    | ImportToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | WithToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | ExportToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     -- Future reserved words

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -248,6 +248,7 @@ instance RenderJS [JSModuleItem] where
     (|>) = foldl' (|>)
 
 instance RenderJS JSModuleItem where
+    (|>) pacc (JSModuleImportDeclaration annot decl) = pacc |> annot |> "import" |> decl
     (|>) pacc (JSModuleExportDeclaration annot decl) = pacc |> annot |> "export" |> decl
     (|>) pacc (JSModuleStatementListItem s) = pacc |> s
 
@@ -273,6 +274,29 @@ instance RenderJS JSArrayElement where
 
 instance RenderJS [JSArrayElement] where
     (|>) = foldl' (|>)
+
+instance RenderJS JSImportDeclaration where
+    (|>) pacc (JSImportDeclaration imp from annot) = pacc |> imp |> from |> annot
+
+instance RenderJS JSImportClause where
+    (|>) pacc (JSImportClauseDefault x) = pacc |> x
+    (|>) pacc (JSImportClauseNameSpace x) = pacc |> x
+    (|>) pacc (JSImportClauseNamed x) = pacc |> x
+    (|>) pacc (JSImportClauseDefaultNameSpace x1 annot x2) = pacc |> x1 |> annot |> "," |> x2
+    (|>) pacc (JSImportClauseDefaultNamed x1 annot x2) = pacc |> x1 |> annot |> "," |> x2
+
+instance RenderJS JSFromClause where
+    (|>) pacc (JSFromClause from annot m) = pacc |> from |> "from" |> annot |> m
+
+instance RenderJS JSImportNameSpace where
+    (|>) pacc (JSImportNameSpace star as x) = pacc |> star |> as |> x
+
+instance RenderJS JSImportsNamed where
+    (|>) pacc (JSImportsNamed lb xs rb) = pacc |> lb |> "{" |> xs |> rb |> "}"
+
+instance RenderJS JSImportSpecifier where
+    (|>) pacc (JSImportSpecifier x1) = pacc |> x1
+    (|>) pacc (JSImportSpecifierAs x1 as x2) = pacc |> x1 |> as |> x2
 
 instance RenderJS JSExportDeclaration where
     (|>) pacc (JSExport x1 s) = pacc |> " " |> x1 |> s

--- a/src/Language/JavaScript/Process/Minify.hs
+++ b/src/Language/JavaScript/Process/Minify.hs
@@ -268,8 +268,39 @@ instance MinifyJS JSAssignOp where
     fix a (JSBwOrAssign   _) = JSBwOrAssign a
 
 instance MinifyJS JSModuleItem where
+    fix _ (JSModuleImportDeclaration _ x1) = JSModuleImportDeclaration emptyAnnot (fixEmpty x1)
     fix _ (JSModuleExportDeclaration _ x1) = JSModuleExportDeclaration emptyAnnot (fixEmpty x1)
     fix a (JSModuleStatementListItem s) = JSModuleStatementListItem (fixStmt a noSemi s)
+
+instance MinifyJS JSImportDeclaration where
+    fix _ (JSImportDeclaration imps from _) = JSImportDeclaration (fixEmpty imps) (fix annot from) noSemi
+        where
+        annot = case imps of
+                    JSImportClauseDefault {} -> spaceAnnot
+                    JSImportClauseNameSpace {} -> spaceAnnot
+                    JSImportClauseNamed {} -> emptyAnnot
+                    JSImportClauseDefaultNameSpace {} -> spaceAnnot
+                    JSImportClauseDefaultNamed {} -> emptyAnnot
+
+instance MinifyJS JSImportClause where
+    fix _ (JSImportClauseDefault n) = JSImportClauseDefault (fixSpace n)
+    fix _ (JSImportClauseNameSpace ns) = JSImportClauseNameSpace (fixSpace ns)
+    fix _ (JSImportClauseNamed named) = JSImportClauseNamed (fixEmpty named)
+    fix _ (JSImportClauseDefaultNameSpace def _ ns) = JSImportClauseDefaultNameSpace (fixSpace def) emptyAnnot (fixEmpty ns)
+    fix _ (JSImportClauseDefaultNamed def _ ns) = JSImportClauseDefaultNamed (fixSpace def) emptyAnnot (fixEmpty ns)
+
+instance MinifyJS JSFromClause where
+    fix a (JSFromClause _ _ m) = JSFromClause a emptyAnnot m
+
+instance MinifyJS JSImportNameSpace where
+    fix a (JSImportNameSpace _ _ ident) = JSImportNameSpace (JSBinOpTimes a) (JSBinOpAs spaceAnnot) (fixSpace ident)
+
+instance MinifyJS JSImportsNamed where
+    fix _ (JSImportsNamed _ imps _) = JSImportsNamed emptyAnnot (fixEmpty imps) emptyAnnot 
+
+instance MinifyJS JSImportSpecifier where
+    fix _ (JSImportSpecifier x1) = JSImportSpecifier (fixEmpty x1)
+    fix _ (JSImportSpecifierAs x1 as x2) = JSImportSpecifierAs (fixEmpty x1) (fixSpace as) (fixSpace x2)
 
 instance MinifyJS JSExportDeclaration where
     fix _ (JSExportLocals _ x1 _ _) = JSExportLocals emptyAnnot (fixEmpty x1) emptyAnnot noSemi

--- a/test/Test/Language/Javascript/Minify.hs
+++ b/test/Test/Language/Javascript/Minify.hs
@@ -255,7 +255,14 @@ testMinifyProg = describe "Minify programs:" $ do
         minifyProg " try { } catch (a) {} finally {} ; try { } catch ( b ) { } ; " `shouldBe` "try{}catch(a){}finally{}try{}catch(b){}"
 
 testMinifyModule :: Spec
-testMinifyModule = describe "Minify modules:" $
+testMinifyModule = describe "Minify modules:" $ do
+    it "import" $ do
+        minifyModule "import  def  from 'mod' ; " `shouldBe` "import def from'mod'"
+        minifyModule "import   *  as  foo  from   \"mod\"  ; " `shouldBe` "import * as foo from\"mod\""
+        minifyModule "import  def, * as foo  from   \"mod\"  ; " `shouldBe` "import def,* as foo from\"mod\""
+        minifyModule "import  { baz,  bar as   foo }  from   \"mod\"  ; " `shouldBe` "import{baz,bar as foo}from\"mod\""
+        minifyModule "import  def, { baz,  bar as   foo }  from   \"mod\"  ; " `shouldBe` "import def,{baz,bar as foo}from\"mod\""
+
     it "export" $ do
         minifyModule " export { } ; " `shouldBe` "export{}"
         minifyModule " export { a } ; " `shouldBe` "export{a}"

--- a/test/Test/Language/Javascript/ModuleParser.hs
+++ b/test/Test/Language/Javascript/ModuleParser.hs
@@ -8,7 +8,30 @@ import Language.JavaScript.Parser
 
 
 testModuleParser :: Spec
-testModuleParser = describe "Parse modules:" $
+testModuleParser = describe "Parse modules:" $ do
+    it "import" $ do
+        -- Not yet supported
+        -- test "import 'a';"            `shouldBe` ""
+
+        test "import def from 'mod';"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseDefault (JSIdentifier 'def'),JSFromClause ''mod''))])"
+        test "import def from \"mod\";"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseDefault (JSIdentifier 'def'),JSFromClause '\"mod\"'))])"
+        test "import * as thing from 'mod';"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseNameSpace (JSImportNameSpace (JSIdentifier 'thing')),JSFromClause ''mod''))])"
+        test "import { foo, bar, baz as quux } from 'mod';"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseNameSpace (JSImportsNamed ((JSImportSpecifier (JSIdentifier 'foo'),JSImportSpecifier (JSIdentifier 'bar'),JSImportSpecifierAs (JSIdentifier 'baz',JSIdentifier 'quux')))),JSFromClause ''mod''))])"
+        test "import def, * as thing from 'mod';"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseDefaultNameSpace (JSIdentifier 'def',JSImportNameSpace (JSIdentifier 'thing')),JSFromClause ''mod''))])"
+        test "import def, { foo, bar, baz as quux } from 'mod';"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleImportDeclaration (JSImportDeclaration (JSImportClauseDefaultNamed (JSIdentifier 'def',JSImportsNamed ((JSImportSpecifier (JSIdentifier 'foo'),JSImportSpecifier (JSIdentifier 'bar'),JSImportSpecifierAs (JSIdentifier 'baz',JSIdentifier 'quux')))),JSFromClause ''mod''))])"
+
     it "export" $ do
         test "export {}"
             `shouldBe`
@@ -25,6 +48,7 @@ testModuleParser = describe "Parse modules:" $
         test "export { a as b };"
             `shouldBe`
             "Right (JSAstModule [JSModuleExportDeclaration (JSExportLocals ((JSExportLocalSpecifierAs (JSIdentifier 'a',JSIdentifier 'b'))))])"
+
 
 test :: String -> String
 test str = showStrippedMaybe (parseModule str "src")

--- a/test/Test/Language/Javascript/RoundTrip.hs
+++ b/test/Test/Language/Javascript/RoundTrip.hs
@@ -101,6 +101,13 @@ testRoundTrip = describe "Roundtrip:" $ do
         testRT "var x=1;let y=2;"
 
     it "module" $ do
+        testRTModule "import  def  from 'mod'"
+        testRTModule "import  def  from   \"mod\";"
+        testRTModule "import   * as foo  from   \"mod\"  ; "
+        testRTModule "import  def, * as foo  from   \"mod\"  ; "
+        testRTModule "import  { baz,  bar as   foo }  from   \"mod\"  ; "
+        testRTModule "import  def, { baz,  bar as   foo }  from   \"mod\"  ; "
+
         testRTModule "export   {};"
         testRTModule "  export {}   ;  "
         testRTModule "export {  a  ,  b  ,  c  };"


### PR DESCRIPTION
This commit adds support for all forms of the ES module import statement
apart from the dynamic 'import()' form and the bare 'import "mod";' form
(where the import is only being performed for the sake of some side
effects).

Supercedes #77, refs #71.