### PR TITLE
Add back support for identifiers named `as`

### DIFF
--- a/src/Language/JavaScript/Parser/AST.hs
+++ b/src/Language/JavaScript/Parser/AST.hs
@@ -87,7 +87,7 @@ data JSFromClause
 
 -- | Import namespace, e.g. '* as whatever'
 data JSImportNameSpace
-    = JSImportNameSpace !JSBinOp !JSBinOp !JSIdent -- ^ *, as, ident
+    = JSImportNameSpace !JSBinOp !JSAnnot !JSIdent -- ^ *, as, ident
     deriving (Data, Eq, Show, Typeable)
 
 -- | Named imports, e.g. '{ foo, bar, baz as quux }'
@@ -100,7 +100,7 @@ data JSImportsNamed
 -- grammar is slightly different (e.g. in handling of reserved words).
 data JSImportSpecifier
     = JSImportSpecifier !JSIdent -- ^ident
-    | JSImportSpecifierAs !JSIdent !JSBinOp !JSIdent -- ^ident, as, ident
+    | JSImportSpecifierAs !JSIdent !JSAnnot !JSIdent -- ^ident, as, ident
     deriving (Data, Eq, Show, Typeable)
 
 data JSExportDeclaration
@@ -113,7 +113,7 @@ data JSExportDeclaration
 
 data JSExportLocalSpecifier
     = JSExportLocalSpecifier !JSIdent -- ^ident
-    | JSExportLocalSpecifierAs !JSIdent !JSBinOp !JSIdent -- ^ident1, as, ident2
+    | JSExportLocalSpecifierAs !JSIdent !JSAnnot !JSIdent -- ^ident1, as, ident2
     deriving (Data, Eq, Show, Typeable)
 
 data JSStatement
@@ -185,7 +185,6 @@ data JSExpression
 
 data JSBinOp
     = JSBinOpAnd !JSAnnot
-    | JSBinOpAs !JSAnnot
     | JSBinOpBitAnd !JSAnnot
     | JSBinOpBitOr !JSAnnot
     | JSBinOpBitXor !JSAnnot
@@ -458,7 +457,6 @@ instance ShowStripped JSSwitchParts where
 
 instance ShowStripped JSBinOp where
     ss (JSBinOpAnd _) = "'&&'"
-    ss (JSBinOpAs _) = "'as'"
     ss (JSBinOpBitAnd _) = "'&'"
     ss (JSBinOpBitOr _) = "'|'"
     ss (JSBinOpBitXor _) = "'^'"
@@ -555,7 +553,6 @@ commaIf xs = ',' : xs
 
 deAnnot :: JSBinOp -> JSBinOp
 deAnnot (JSBinOpAnd _) = JSBinOpAnd JSNoAnnot
-deAnnot (JSBinOpAs _) = JSBinOpAs JSNoAnnot
 deAnnot (JSBinOpBitAnd _) = JSBinOpBitAnd JSNoAnnot
 deAnnot (JSBinOpBitOr _) = JSBinOpBitOr JSNoAnnot
 deAnnot (JSBinOpBitXor _) = JSBinOpBitXor JSNoAnnot

--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -194,6 +194,9 @@ Spread : '...' { mkJSAnnot $1 }
 Dot :: { AST.JSAnnot }
 Dot : '.' { mkJSAnnot $1 }
 
+As :: { AST.JSAnnot }
+As : 'as' { mkJSAnnot $1 }
+
 Increment :: { AST.JSUnaryOp }
 Increment : '++' { AST.JSUnaryOpIncr (mkJSAnnot $1) }
 
@@ -250,9 +253,6 @@ Ge : '>=' { AST.JSBinOpGe (mkJSAnnot $1) }
 
 Gt :: { AST.JSBinOp }
 Gt : '>' { AST.JSBinOpGt (mkJSAnnot $1) }
-
-As :: { AST.JSBinOp }
-As : 'as' { AST.JSBinOpAs (mkJSAnnot $1) }
 
 In :: { AST.JSBinOp }
 In : 'in' { AST.JSBinOpIn (mkJSAnnot $1) }
@@ -442,6 +442,7 @@ PrimaryExpression : 'this'                   { AST.JSLiteral (mkJSAnnot $1) "thi
 --         IdentifierName IdentifierPart
 Identifier :: { AST.JSExpression }
 Identifier : 'ident' { AST.JSIdentifier (mkJSAnnot $1) (tokenLiteral $1) }
+           | 'as'    { AST.JSIdentifier (mkJSAnnot $1) "as" }
            | 'get'   { AST.JSIdentifier (mkJSAnnot $1) "get" }
            | 'set'   { AST.JSIdentifier (mkJSAnnot $1) "set" }
            | 'from'  { AST.JSIdentifier (mkJSAnnot $1) "from" }

--- a/src/Language/JavaScript/Parser/Lexer.x
+++ b/src/Language/JavaScript/Parser/Lexer.x
@@ -503,8 +503,7 @@ keywords = Map.fromList keywordNames
 
 keywordNames :: [(String, TokenPosn -> String -> [CommentAnnotation] -> Token)]
 keywordNames =
-    [ ( "as", AsToken )
-    , ( "break", BreakToken )
+    [ ( "break", BreakToken )
     , ( "case", CaseToken )
     , ( "catch", CatchToken )
 
@@ -549,6 +548,7 @@ keywordNames =
     , ( "with", WithToken )
     -- TODO: no idea if these are reserved or not, but they are needed
     --       handled in parser, in the Identifier rule
+    , ( "as", AsToken ) -- not reserved
     , ( "get", GetToken )
     , ( "set", SetToken )
     {- Come from Table 6 of ECMASCRIPT 5.1, Attributes of a Named Accessor Property

--- a/src/Language/JavaScript/Parser/Token.hs
+++ b/src/Language/JavaScript/Parser/Token.hs
@@ -56,7 +56,6 @@ data Token
     -- ^ Literal: Regular Expression
 
     -- Keywords
-    | AsToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | BreakToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | CaseToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | CatchToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
@@ -155,6 +154,7 @@ data Token
     | CondcommentEndToken { tokenSpan :: !TokenPosn, tokenComment :: ![CommentAnnotation]  }
 
     -- Special cases
+    | AsToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | TailToken { tokenSpan :: !TokenPosn, tokenComment :: ![CommentAnnotation]  } -- ^ Stuff between last JS and EOF
     | EOFToken { tokenSpan :: !TokenPosn, tokenComment :: ![CommentAnnotation]  }  -- ^ End of file
     deriving (Eq, Show, Typeable)

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -139,7 +139,6 @@ instance RenderJS [JSExpression] where
 
 instance RenderJS JSBinOp where
     (|>) pacc (JSBinOpAnd        annot)  = pacc |> annot |> "&&"
-    (|>) pacc (JSBinOpAs         annot)  = pacc |> annot |> "as"
     (|>) pacc (JSBinOpBitAnd     annot)  = pacc |> annot |> "&"
     (|>) pacc (JSBinOpBitOr      annot)  = pacc |> annot |> "|"
     (|>) pacc (JSBinOpBitXor     annot)  = pacc |> annot |> "^"
@@ -295,14 +294,14 @@ instance RenderJS JSFromClause where
     (|>) pacc (JSFromClause from annot m) = pacc |> from |> "from" |> annot |> m
 
 instance RenderJS JSImportNameSpace where
-    (|>) pacc (JSImportNameSpace star as x) = pacc |> star |> as |> x
+    (|>) pacc (JSImportNameSpace star annot x) = pacc |> star |> annot |> "as" |> x
 
 instance RenderJS JSImportsNamed where
     (|>) pacc (JSImportsNamed lb xs rb) = pacc |> lb |> "{" |> xs |> rb |> "}"
 
 instance RenderJS JSImportSpecifier where
     (|>) pacc (JSImportSpecifier x1) = pacc |> x1
-    (|>) pacc (JSImportSpecifierAs x1 as x2) = pacc |> x1 |> as |> x2
+    (|>) pacc (JSImportSpecifierAs x1 annot x2) = pacc |> x1 |> annot |> "as" |> x2
 
 instance RenderJS JSExportDeclaration where
     (|>) pacc (JSExport x1 s) = pacc |> " " |> x1 |> s
@@ -311,7 +310,7 @@ instance RenderJS JSExportDeclaration where
 
 instance RenderJS JSExportLocalSpecifier where
     (|>) pacc (JSExportLocalSpecifier i) = pacc |> i
-    (|>) pacc (JSExportLocalSpecifierAs x1 as x2) = pacc |> x1 |> as |> x2
+    (|>) pacc (JSExportLocalSpecifierAs x1 annot x2) = pacc |> x1 |> annot |> "as" |> x2
 
 instance RenderJS a => RenderJS (JSCommaList a) where
     (|>) pacc (JSLCons pl a i) = pacc |> pl |> a |> "," |> i

--- a/src/Language/JavaScript/Process/Minify.hs
+++ b/src/Language/JavaScript/Process/Minify.hs
@@ -215,7 +215,6 @@ normalizeToSQ str =
 
 instance MinifyJS JSBinOp where
     fix _ (JSBinOpAnd        _) = JSBinOpAnd emptyAnnot
-    fix a (JSBinOpAs         _) = JSBinOpAs a
     fix _ (JSBinOpBitAnd     _) = JSBinOpBitAnd emptyAnnot
     fix _ (JSBinOpBitOr      _) = JSBinOpBitOr emptyAnnot
     fix _ (JSBinOpBitXor     _) = JSBinOpBitXor emptyAnnot
@@ -299,14 +298,14 @@ instance MinifyJS JSFromClause where
     fix a (JSFromClause _ _ m) = JSFromClause a emptyAnnot m
 
 instance MinifyJS JSImportNameSpace where
-    fix a (JSImportNameSpace _ _ ident) = JSImportNameSpace (JSBinOpTimes a) (JSBinOpAs spaceAnnot) (fixSpace ident)
+    fix a (JSImportNameSpace _ _ ident) = JSImportNameSpace (JSBinOpTimes a) spaceAnnot (fixSpace ident)
 
 instance MinifyJS JSImportsNamed where
-    fix _ (JSImportsNamed _ imps _) = JSImportsNamed emptyAnnot (fixEmpty imps) emptyAnnot 
+    fix _ (JSImportsNamed _ imps _) = JSImportsNamed emptyAnnot (fixEmpty imps) emptyAnnot
 
 instance MinifyJS JSImportSpecifier where
     fix _ (JSImportSpecifier x1) = JSImportSpecifier (fixEmpty x1)
-    fix _ (JSImportSpecifierAs x1 as x2) = JSImportSpecifierAs (fixEmpty x1) (fixSpace as) (fixSpace x2)
+    fix _ (JSImportSpecifierAs x1 _ x2) = JSImportSpecifierAs (fixEmpty x1) spaceAnnot (fixSpace x2)
 
 instance MinifyJS JSExportDeclaration where
     fix _ (JSExportLocals _ x1 _ _) = JSExportLocals emptyAnnot (fixEmpty x1) emptyAnnot noSemi
@@ -314,7 +313,7 @@ instance MinifyJS JSExportDeclaration where
 
 instance MinifyJS JSExportLocalSpecifier where
     fix _ (JSExportLocalSpecifier x1) = JSExportLocalSpecifier (fixEmpty x1)
-    fix _ (JSExportLocalSpecifierAs x1 as x2) = JSExportLocalSpecifierAs (fixEmpty x1) (fixSpace as) (fixSpace x2)
+    fix _ (JSExportLocalSpecifierAs x1 _ x2) = JSExportLocalSpecifierAs (fixEmpty x1) spaceAnnot (fixSpace x2)
 
 instance MinifyJS JSTryCatch where
     fix a (JSCatch _ _ x1 _ x3) = JSCatch a emptyAnnot (fixEmpty x1) emptyAnnot (fixEmpty x3)

--- a/test/Test/Language/Javascript/ModuleParser.hs
+++ b/test/Test/Language/Javascript/ModuleParser.hs
@@ -9,6 +9,11 @@ import Language.JavaScript.Parser
 
 testModuleParser :: Spec
 testModuleParser = describe "Parse modules:" $ do
+    it "as" $
+        test "as"
+            `shouldBe`
+            "Right (JSAstModule [JSModuleStatementListItem (JSIdentifier 'as')])"
+
     it "import" $ do
         -- Not yet supported
         -- test "import 'a';"            `shouldBe` ""


### PR DESCRIPTION
Turns out 'as' _isn’t_ actually a keyword: https://www.ecma-international.org/ecma-262/#prod-Keyword.