### PR TITLE
Fix lexer bug involving template literals

### DIFF
--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -9,6 +9,7 @@ module Language.JavaScript.Parser.Grammar7
     ) where
 
 import Data.Char
+import Data.Functor (($>))
 import Language.JavaScript.Parser.Lexer
 import Language.JavaScript.Parser.ParserMonad
 import Language.JavaScript.Parser.SrcLocation
@@ -505,8 +506,16 @@ TemplateLiteral : 'tmplnosub'              { JSUntaggedTemplate (mkJSAnnot $1) (
                 | 'tmplhead' TemplateParts { JSUntaggedTemplate (mkJSAnnot $1) (tokenLiteral $1) $2 }
 
 TemplateParts :: { [AST.JSTemplatePart] }
-TemplateParts : Expression 'tmplmiddle' TemplateParts { AST.JSTemplatePart $1 (mkJSAnnot $2) (tokenLiteral $2) : $3 }
-              | Expression 'tmpltail'                 { AST.JSTemplatePart $1 (mkJSAnnot $2) (tokenLiteral $2) : [] }
+TemplateParts : TemplateExpression RBrace 'tmplmiddle' TemplateParts { AST.JSTemplatePart $1 $2 ('}' : tokenLiteral $3) : $4 }
+              | TemplateExpression RBrace 'tmpltail'                 { AST.JSTemplatePart $1 $2 ('}' : tokenLiteral $3) : [] }
+
+-- This production only exists to ensure that inTemplate is set to True before
+-- a tmplmiddle or tmpltail token is lexed. Since the lexer is always one token
+-- ahead of the parser, setInTemplate needs to be called during a reduction
+-- that is *two* tokens behind tmplmiddle/tmpltail. Accordingly,
+-- TemplateExpression is always followed by an RBrace, which is lexed normally.
+TemplateExpression :: { AST.JSExpression }
+TemplateExpression : Expression {% setInTemplate True \$> $1 }
 
 -- ArrayLiteral :                                                        See 11.1.4
 --        [ Elisionopt ]

--- a/src/Language/JavaScript/Parser/ParserMonad.hs
+++ b/src/Language/JavaScript/Parser/ParserMonad.hs
@@ -21,12 +21,14 @@ import Language.JavaScript.Parser.SrcLocation
 data AlexUserState = AlexUserState
     { previousToken :: !Token   -- ^the previous token
     , comment :: [Token]        -- ^the previous comment, if any
+    , inTemplate :: Bool        -- ^whether the parser is expecting template characters
     }
 
 alexInitUserState :: AlexUserState
 alexInitUserState = AlexUserState
     { previousToken = initToken
     , comment = []
+    , inTemplate = False
     }
 
 initToken :: Token

--- a/test/Test/Language/Javascript/RoundTrip.hs
+++ b/test/Test/Language/Javascript/RoundTrip.hs
@@ -85,6 +85,8 @@ testRoundTrip = describe "Roundtrip:" $ do
         testRT "/*a*/`<${/*b*/x/*c*/}>`/*d*/"
         testRT "`\\${}`"
         testRT "`\n\n`"
+        testRT "{}+``"
+        -- ^ https://github.com/erikd/language-javascript/issues/104
 
 
     it "statement" $ do


### PR DESCRIPTION
In any program where a `}` character occurred anywhere before a template
literal, the lexer was incorrectly tokenizing the `}` and all characters
up through the initial backquote as a template tail. By adding an
additional piece of state to the parser monad, the lexer now will only
recognize a TemplateMiddleToken or a TemplateTailToken if the parser is
expecting one.

Fixes #104.