### PR TITLE
Warn about UTF-8 requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ this github repository.
 How to build
 ------------
 
+Make sure your locale supports UTF-8. For example, on most Unix-like platforms,
+you can type:
+
+    export LC_ALL=en_US.UTF-8
+
 Library:
 
     cabal clean && cabal configure && cabal build


### PR DESCRIPTION
It is quite common for this library to be required on platforms where a UTF-8 locale is not the default, e.g. bare-bones Docker containers and other virtualization environments, CI build scripts, etc. For people not familiar with the UTF-8 requirement of this library, the errors in the resulting build failures are not helpful, and diagnosing the failure can be a long and painful process.

Let's start with at least making the requirement clear in the README.md. We might also consider actually checking it at build time, e.g. using `runIO` from TH, so that we can provide a helpful error message.