### PR TITLE
Add support for spread expressions in object literals

### DIFF
--- a/src/Language/JavaScript/Parser/AST.hs
+++ b/src/Language/JavaScript/Parser/AST.hs
@@ -297,6 +297,7 @@ data JSObjectProperty
     = JSPropertyNameandValue !JSPropertyName !JSAnnot ![JSExpression] -- ^name, colon, value
     | JSPropertyIdentRef !JSAnnot !String
     | JSObjectMethod !JSMethodDefinition
+    | JSObjectSpread !JSAnnot !JSExpression
     deriving (Data, Eq, Show, Typeable)
 
 data JSMethodDefinition
@@ -512,6 +513,7 @@ instance ShowStripped JSObjectProperty where
     ss (JSPropertyNameandValue x1 _colon x2s) = "JSPropertyNameandValue (" ++ ss x1 ++ ") " ++ ss x2s
     ss (JSPropertyIdentRef _ s) = "JSPropertyIdentRef " ++ singleQuote s
     ss (JSObjectMethod m) = ss m
+    ss (JSObjectSpread _ellipsis e) = "JSObjectSpread " ++ ss e
 
 instance ShowStripped JSMethodDefinition where
     ss (JSMethodDefinition x1 _lb1 x2s _rb1 x3) = "JSMethodDefinition (" ++ ss x1 ++ ") " ++ ss x2s ++ " (" ++ ss x3 ++ ")"

--- a/src/Language/JavaScript/Parser/AST.hs
+++ b/src/Language/JavaScript/Parser/AST.hs
@@ -513,7 +513,7 @@ instance ShowStripped JSObjectProperty where
     ss (JSPropertyNameandValue x1 _colon x2s) = "JSPropertyNameandValue (" ++ ss x1 ++ ") " ++ ss x2s
     ss (JSPropertyIdentRef _ s) = "JSPropertyIdentRef " ++ singleQuote s
     ss (JSObjectMethod m) = ss m
-    ss (JSObjectSpread _ellipsis e) = "JSObjectSpread " ++ ss e
+    ss (JSObjectSpread _ x1) = "JSObjectSpread (" ++ ss x1 ++ ")"
 
 instance ShowStripped JSMethodDefinition where
     ss (JSMethodDefinition x1 _lb1 x2s _rb1 x3) = "JSMethodDefinition (" ++ ss x1 ++ ") " ++ ss x2s ++ " (" ++ ss x3 ++ ")"

--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -611,6 +611,7 @@ PropertyAssignment :: { AST.JSObjectProperty }
 PropertyAssignment : PropertyName Colon AssignmentExpression { AST.JSPropertyNameandValue $1 $2 [$3] }
                    | IdentifierName { identifierToProperty $1 }
                    | MethodDefinition { AST.JSObjectMethod $1 }
+                   | SpreadExpression { spreadExpressionToProperty $1 }
 
 -- TODO: not clear if get/set are keywords, or just used in a specific context. Puzzling.
 MethodDefinition :: { AST.JSMethodDefinition }
@@ -1563,6 +1564,9 @@ propName (AST.JSHexInteger a s) = AST.JSPropertyNumber a s
 propName (AST.JSOctal a s) = AST.JSPropertyNumber a s
 propName (AST.JSStringLiteral a s) = AST.JSPropertyString a s
 propName x = error $ "Cannot convert '" ++ show x ++ "' to a JSPropertyName."
+
+spreadExpressionToProperty :: AST.JSExpression -> AST.JSObjectProperty
+spreadExpressionToProperty (AST.JSSpreadExpression d e) = AST.JSObjectSpread d e
 
 identifierToProperty :: AST.JSExpression -> AST.JSObjectProperty
 identifierToProperty (AST.JSIdentifier a s) = AST.JSPropertyIdentRef a s

--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -1567,10 +1567,11 @@ propName x = error $ "Cannot convert '" ++ show x ++ "' to a JSPropertyName."
 
 spreadExpressionToProperty :: AST.JSExpression -> AST.JSObjectProperty
 spreadExpressionToProperty (AST.JSSpreadExpression d e) = AST.JSObjectSpread d e
+spreadExpressionToProperty x = error $ "Cannot convert '" ++ show x ++ "' to a JSSpreadExpression."
 
 identifierToProperty :: AST.JSExpression -> AST.JSObjectProperty
 identifierToProperty (AST.JSIdentifier a s) = AST.JSPropertyIdentRef a s
-identifierToProperty x = error $ "Cannot convert '" ++ show x ++ "' to a JSObjectProperty."
+identifierToProperty x = error $ "Cannot convert '" ++ show x ++ "' to a JSPropertyIdentRef."
 
 toArrowParameterList :: AST.JSExpression -> Token -> Alex AST.JSArrowParameterList
 toArrowParameterList (AST.JSIdentifier a s)          = const . return $ AST.JSUnparenthesizedArrowParameter (AST.JSIdentName a s)

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -281,7 +281,7 @@ instance RenderJS JSObjectProperty where
     (|>) pacc (JSPropertyNameandValue n c vs)                 = pacc |> n |> c |> ":" |> vs
     (|>) pacc (JSPropertyIdentRef     a s)                    = pacc |> a |> s
     (|>) pacc (JSObjectMethod         m)                      = pacc |> m
-    (|>) pacc (JSObjectSpread         d e)                    = pacc |> d |> "..." |> e
+    (|>) pacc (JSObjectSpread         a e)                    = pacc |> a |> "..." |> e
 
 instance RenderJS JSMethodDefinition where
     (|>) pacc (JSMethodDefinition          n alp ps arp b)   = pacc |> n |> alp |> "(" |> ps |> arp |> ")" |> b

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -281,6 +281,7 @@ instance RenderJS JSObjectProperty where
     (|>) pacc (JSPropertyNameandValue n c vs)                 = pacc |> n |> c |> ":" |> vs
     (|>) pacc (JSPropertyIdentRef     a s)                    = pacc |> a |> s
     (|>) pacc (JSObjectMethod         m)                      = pacc |> m
+    (|>) pacc (JSObjectSpread         d e)                    = pacc |> d |> "..." |> e
 
 instance RenderJS JSMethodDefinition where
     (|>) pacc (JSMethodDefinition          n alp ps arp b)   = pacc |> n |> alp |> "(" |> ps |> arp |> ")" |> b

--- a/src/Language/JavaScript/Process/Minify.hs
+++ b/src/Language/JavaScript/Process/Minify.hs
@@ -370,6 +370,7 @@ instance MinifyJS JSObjectProperty where
     fix a (JSPropertyNameandValue n _ vs)       = JSPropertyNameandValue (fix a n) emptyAnnot (map fixEmpty vs)
     fix a (JSPropertyIdentRef     _ s)          = JSPropertyIdentRef a s
     fix a (JSObjectMethod         m)            = JSObjectMethod (fix a m)
+    fix a (JSObjectSpread         _ e)          = JSObjectSpread emptyAnnot (fix a e)
 
 instance MinifyJS JSMethodDefinition where
     fix a (JSMethodDefinition          n _ ps _ b)   = JSMethodDefinition                     (fix a n)    emptyAnnot (fixEmpty ps) emptyAnnot (fixEmpty b)

--- a/src/Language/JavaScript/Process/Minify.hs
+++ b/src/Language/JavaScript/Process/Minify.hs
@@ -370,7 +370,7 @@ instance MinifyJS JSObjectProperty where
     fix a (JSPropertyNameandValue n _ vs)       = JSPropertyNameandValue (fix a n) emptyAnnot (map fixEmpty vs)
     fix a (JSPropertyIdentRef     _ s)          = JSPropertyIdentRef a s
     fix a (JSObjectMethod         m)            = JSObjectMethod (fix a m)
-    fix a (JSObjectSpread         _ e)          = JSObjectSpread emptyAnnot (fix a e)
+    fix a (JSObjectSpread         _ e)          = JSObjectSpread a (fixEmpty e)
 
 instance MinifyJS JSMethodDefinition where
     fix a (JSMethodDefinition          n _ ps _ b)   = JSMethodDefinition                     (fix a n)    emptyAnnot (fixEmpty ps) emptyAnnot (fixEmpty b)

--- a/test/Test/Language/Javascript/Minify.hs
+++ b/test/Test/Language/Javascript/Minify.hs
@@ -46,6 +46,8 @@ testMinifyExpr = describe "Minify expressions:" $ do
         minifyExpr " { a ( x, y ) { } } " `shouldBe` "{a(x,y){}}"
         minifyExpr " { [ x + y ] ( ) { } } " `shouldBe` "{[x+y](){}}"
         minifyExpr " { * a ( x, y ) { } } " `shouldBe` "{*a(x,y){}}"
+        minifyExpr " { ...z } " `shouldBe` "{...z}"
+        minifyExpr " { ...w, x: 3, ...y, z: 4, ...o }" `shouldBe` "{...w,x:3,...y,z:4,...o}"
 
     it "parentheses" $ do
         minifyExpr " ( 'hello' ) " `shouldBe` "('hello')"


### PR DESCRIPTION
Related to #71. Support for spread expressions was added for all contexts other than object literals. This PR adds support for them in object literals, too.