### PR TITLE
Support export *

### DIFF
--- a/src/Language/JavaScript/Parser/AST.hs
+++ b/src/Language/JavaScript/Parser/AST.hs
@@ -110,8 +110,8 @@ data JSImportSpecifier
     deriving (Data, Eq, Show, Typeable)
 
 data JSExportDeclaration
-    -- = JSExportAllFrom
-    = JSExportFrom JSExportClause JSFromClause !JSSemi -- ^exports, module, semi
+    = JSExportAllFrom !JSBinOp !JSFromClause !JSSemi -- ^*, module, semi
+    | JSExportFrom !JSExportClause JSFromClause !JSSemi -- ^exports, module, semi
     | JSExportLocals JSExportClause !JSSemi -- ^exports, autosemi
     | JSExport !JSStatement !JSSemi -- ^body, autosemi
     -- | JSExportDefault
@@ -485,6 +485,7 @@ instance ShowStripped JSImportSpecifier where
     ss (JSImportSpecifierAs x1 _ x2) = "JSImportSpecifierAs (" ++ ss x1 ++ "," ++ ss x2 ++ ")"
 
 instance ShowStripped JSExportDeclaration where
+    ss (JSExportAllFrom _ from _) = "JSExportAllFrom (" ++ ss from ++ ")"
     ss (JSExportFrom xs from _) = "JSExportFrom (" ++ ss xs ++ "," ++ ss from ++ ")"
     ss (JSExportLocals xs _) = "JSExportLocals (" ++ ss xs ++ ")"
     ss (JSExport x1 _) = "JSExport (" ++ ss x1 ++ ")"

--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -1434,7 +1434,7 @@ ImportSpecifier : IdentifierName
                     { AST.JSImportSpecifierAs (identName $1) $2 (identName $3) }
 
 -- ExportDeclaration :                                                        See 15.2.3
--- [ ]    export * FromClause ;
+-- [x]    export * FromClause ;
 -- [x]    export ExportClause FromClause ;
 -- [x]    export ExportClause ;
 -- [x]    export VariableStatement
@@ -1452,7 +1452,9 @@ ImportSpecifier : IdentifierName
 -- [ ]    export default ClassDeclaration[Default]
 -- [ ]    export default [lookahead ∉ { function, class }] AssignmentExpression[In] ;
 ExportDeclaration :: { AST.JSExportDeclaration }
-ExportDeclaration : ExportClause FromClause AutoSemi
+ExportDeclaration : Mul FromClause AutoSemi
+                         { AST.JSExportAllFrom $1 $2 $3 {- 'ExportDeclaration0' -} }
+                  | ExportClause FromClause AutoSemi
                          { AST.JSExportFrom $1 $2 $3  {- 'ExportDeclaration1' -} }
                   | ExportClause AutoSemi
                          { AST.JSExportLocals $1 $2   {- 'ExportDeclaration2' -} }

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -332,6 +332,7 @@ instance RenderJS JSExportDeclaration where
     (|>) pacc (JSExport x1 s) = pacc |> x1 |> s
     (|>) pacc (JSExportLocals xs semi) = pacc |> xs |> semi
     (|>) pacc (JSExportFrom xs from semi) = pacc |> xs |> from |> semi
+    (|>) pacc (JSExportAllFrom star from semi) = pacc |> star |> from |> semi
 
 instance RenderJS JSExportClause where
     (|>) pacc (JSExportClause alb JSLNil arb) = pacc |> alb |> "{" |> arb |> "}"

--- a/src/Language/JavaScript/Process/Minify.hs
+++ b/src/Language/JavaScript/Process/Minify.hs
@@ -326,6 +326,7 @@ instance MinifyJS JSImportSpecifier where
     fix _ (JSImportSpecifierAs x1 _ x2) = JSImportSpecifierAs (fixEmpty x1) spaceAnnot (fixSpace x2)
 
 instance MinifyJS JSExportDeclaration where
+    fix a (JSExportAllFrom _ from _) = JSExportAllFrom (JSBinOpTimes a) (fix a from) noSemi
     fix a (JSExportFrom x1 from _) = JSExportFrom (fix a x1) (fix a from) noSemi
     fix _ (JSExportLocals x1 _) = JSExportLocals (fix emptyAnnot x1) noSemi
     fix _ (JSExport x1 _) = JSExport (fixStmt spaceAnnot noSemi x1) noSemi

--- a/test/Test/Language/Javascript/Minify.hs
+++ b/test/Test/Language/Javascript/Minify.hs
@@ -331,6 +331,7 @@ testMinifyModule = describe "Minify modules:" $ do
         minifyModule " export const a = 1 ; " `shouldBe` "export const a=1"
         minifyModule " export function f () {  } ; " `shouldBe` "export function f(){}"
         minifyModule " export function * f () {  } ; " `shouldBe` "export function*f(){}"
+        minifyModule " export * from \"mod\" ; " `shouldBe` "export*from\"mod\""
 
 -- -----------------------------------------------------------------------------
 -- Minify test helpers.


### PR DESCRIPTION
See #124

```
λ> parseModule "export * from 'lib.mjs';" "src"
Right (JSAstModule [JSModuleExportDeclaration (JSAnnot (TokenPn 0 1 1) []) (JSExportAllFrom (JSBinOpTimes (JSAnnot (TokenPn 7 1 8) [WhiteSpace (TokenPn 6 1 7) " "])) (JSFromClause (JSAnnot (TokenPn 9 1 10) [WhiteSpace (TokenPn 8 1 9) " "]) (JSAnnot (TokenPn 14 1 15) [WhiteSpace (TokenPn 13 1 14) " "]) "'lib.mjs'") (JSSemi (JSAnnot (TokenPn 23 1 24) [])))] (JSAnnot (TokenPn 0 0 0) []))
```