### PR TITLE
Add support for MetaProperty (`import.meta` and `new.target`)

### DIFF
--- a/src/Language/JavaScript/Parser/AST.hs
+++ b/src/Language/JavaScript/Parser/AST.hs
@@ -192,6 +192,7 @@ data JSExpression
     | JSFunctionExpression !JSAnnot !JSIdent !JSAnnot !(JSCommaList JSExpression) !JSAnnot !JSBlock -- ^fn,name,lb, parameter list,rb,block`
     | JSGeneratorExpression !JSAnnot !JSAnnot !JSIdent !JSAnnot !(JSCommaList JSExpression) !JSAnnot !JSBlock -- ^fn,*,name,lb, parameter list,rb,block`
     | JSMemberDot !JSExpression !JSAnnot !JSExpression -- ^firstpart, dot, name
+    | JSMetaProperty !JSExpression !JSAnnot !JSExpression -- ^firstpart, dot, secondpart
     | JSMemberExpression !JSExpression !JSAnnot !(JSCommaList JSExpression) !JSAnnot -- expr, lb, args, rb
     | JSMemberNew !JSAnnot !JSExpression !JSAnnot !(JSCommaList JSExpression) !JSAnnot -- ^new, name, lb, args, rb
     | JSMemberSquare !JSExpression !JSAnnot !JSExpression !JSAnnot -- ^firstpart, lb, expr, rb
@@ -435,6 +436,7 @@ instance ShowStripped JSExpression where
     ss (JSLiteral _ []) = "JSLiteral ''"
     ss (JSLiteral _ s) = "JSLiteral " ++ singleQuote s
     ss (JSMemberDot x1s _d x2 ) = "JSMemberDot (" ++ ss x1s ++ "," ++ ss x2 ++ ")"
+    ss (JSMetaProperty _a _d _b ) = "JSMetaProperty (" ++ ss _a ++ "," ++ ss _b ++ ")"
     ss (JSMemberExpression e _ a _) = "JSMemberExpression (" ++ ss e ++ ",JSArguments " ++ ss a ++ ")"
     ss (JSMemberNew _a n _ s _) = "JSMemberNew (" ++ ss n ++ ",JSArguments " ++ ss s ++ ")"
     ss (JSMemberSquare x1s _lb x2 _rb) = "JSMemberSquare (" ++ ss x1s ++ "," ++ ss x2 ++ ")"

--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -148,6 +148,9 @@ import qualified Language.JavaScript.Parser.AST as AST
 
      'tail'       { TailToken {} }
 
+     'target'     { TargetToken {} }
+     'meta'       { MetaToken {} }
+
 
 %%
 
@@ -465,6 +468,12 @@ Static : 'static' { mkJSAnnot $1 }
 Super :: { AST.JSExpression }
 Super : 'super' { AST.JSLiteral (mkJSAnnot $1) "super" }
 
+Target :: { AST.JSExpression }
+Target : 'target' { AST.JSLiteral (mkJSAnnot $1) "target" }
+
+Meta :: { AST.JSExpression }
+Meta : 'meta' { AST.JSLiteral (mkJSAnnot $1) "meta" }
+
 
 Eof :: { AST.JSAnnot }
 Eof : 'tail' { mkJSAnnot $1 {- 'Eof' -} }
@@ -644,6 +653,10 @@ PropertyName : IdentifierName { propName $1 {- 'PropertyName1' -} }
 PropertySetParameterList :: { AST.JSExpression }
 PropertySetParameterList : AssignmentExpression { $1 {- 'PropertySetParameterList' -} }
 
+MetaProperty :: { AST.JSExpression }
+MetaProperty : New Dot Target { AST.JSMetaProperty (AST.JSLiteral $1 "new") $2 $3 }
+             | Import Dot Meta { AST.JSMetaProperty (AST.JSLiteral $1 "import") $2 $3 }
+
 -- MemberExpression :                                           See 11.2
 --        PrimaryExpression
 --        FunctionExpression
@@ -658,6 +671,7 @@ MemberExpression : PrimaryExpression   { $1 {- 'MemberExpression1' -} }
                  | MemberExpression TemplateLiteral            { mkJSTemplateLiteral (Just $1) $2 }
                  | Super LSquare Expression RSquare            { AST.JSMemberSquare $1 $2 $3 $4 }
                  | Super Dot IdentifierName                    { AST.JSMemberDot $1 $2 $3 }
+                 | MetaProperty                                { $1 }
                  | New MemberExpression Arguments              { mkJSMemberNew $1 $2 $3         {- 'MemberExpression5' -} }
 
 -- NewExpression :                                              See 11.2

--- a/src/Language/JavaScript/Parser/Token.hs
+++ b/src/Language/JavaScript/Parser/Token.hs
@@ -105,6 +105,10 @@ data Token
     | GetToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
     | SetToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
 
+    -- MetaProperty
+    | TargetToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
+    | MetaToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }
+
     -- Delimiters
     -- Operators
     | AutoSemiToken { tokenSpan :: !TokenPosn, tokenLiteral :: !String, tokenComment :: ![CommentAnnotation]  }


### PR DESCRIPTION
WIP

Fixes #127 

[ImportMeta](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ImportMeta) is one of the paths for [MetaProperty](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-MetaProperty), which is one of the paths for [MemberExpression](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-MemberExpression).

Since `meta` and `target` are not keywords, I'm not sure how to properly account for them in the Lexer without making every instance of `meta` or `target` be parsed as `MetaToken` or `TargetToken`. I thought I could follow what's currently being done for `GetToken` and `SetToken`, but I'm guessing that's incorrect.