### PR TITLE
Autosemi after comments

### DIFF
--- a/src/Language/JavaScript/Parser/Lexer.x
+++ b/src/Language/JavaScript/Parser/Lexer.x
@@ -14,8 +14,8 @@ module Language.JavaScript.Parser.Lexer
     , lexCont
     , alexError
     , runAlex
-    , happyTestTokeniser
-    , alexTestTokeniser
+    , happyTestTokenizer
+    , alexTestTokenizer
     , setInTemplate
     ) where
 
@@ -412,8 +412,8 @@ lexToken = do
                     return tok
 
 -- For tesing.
-alexTestTokeniser :: String -> Either String [Token]
-alexTestTokeniser input =
+alexTestTokenizer :: String -> Either String [Token]
+alexTestTokenizer input =
     runAlex input $ loop []
   where
     loop acc = do
@@ -426,10 +426,10 @@ alexTestTokeniser input =
                             xs -> reverse xs
             _ -> loop (tok:acc)
 
--- Test variant of alexTestTokeniser
+-- Test variant of alexTestTokenizer
 -- that tokenizes using the same rules as those used by the happy parser
-happyTestTokeniser :: String -> Either String [Token]
-happyTestTokeniser input = runAlex input $ loop []
+happyTestTokenizer :: String -> Either String [Token]
+happyTestTokenizer input = runAlex input $ loop []
   where
     loop :: [Token] -> Alex [Token]
     loop acc = genericLexStep (loop . (:acc)) (loop acc) (\_ ->

--- a/test/Test/Language/Javascript/Lexer.hs
+++ b/test/Test/Language/Javascript/Lexer.hs
@@ -15,6 +15,15 @@ testLexer = describe "Lexer:" $ do
         testLex "// 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 "    `shouldBe` "[CommentToken]"
         testLex "/* 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 */"  `shouldBe` "[CommentToken]"
 
+    it "return mixed with comments" $ do
+        testLex "return 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
+        testLex "return \n 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
+        testLex "return //hello"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
+        testLex "return /*hello*/"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
+        testLex "return //hello\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
+        testLex "return /*hello*/\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
+        testLex "return /*hello 1*/\n"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken]"
+
     it "numbers" $ do
         testLex "123"       `shouldBe` "[DecimalToken 123]"
         testLex "037"       `shouldBe` "[OctalToken 037]"

--- a/test/Test/Language/Javascript/Lexer.hs
+++ b/test/Test/Language/Javascript/Lexer.hs
@@ -167,10 +167,10 @@ testLexer = describe "Lexer:" $ do
 
 
 alexTestLex :: String -> String
-alexTestLex = genericTestLex alexTestTokeniser
+alexTestLex = genericTestLex alexTestTokenizer
 
 happyTestLex :: String -> String
-happyTestLex = genericTestLex happyTestTokeniser
+happyTestLex = genericTestLex happyTestTokenizer
 
 genericTestLex :: (String -> Either String [Token]) -> String -> String
 genericTestLex lexer str =

--- a/test/Test/Language/Javascript/Lexer.hs
+++ b/test/Test/Language/Javascript/Lexer.hs
@@ -11,80 +11,170 @@ import Language.JavaScript.Parser.Lexer
 
 testLexer :: Spec
 testLexer = describe "Lexer:" $ do
-    it "comments" $ do
-        testLex "// 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 "    `shouldBe` "[CommentToken]"
-        testLex "/* 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 */"  `shouldBe` "[CommentToken]"
+    describe "with Alex rules" $ do
+        it "comments" $ do
+            alexTestLex "// 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 "    `shouldBe` "[CommentToken]"
+            alexTestLex "/* 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 */"  `shouldBe` "[CommentToken]"
 
-    it "return mixed with comments" $ do
-        testLex "return 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
-        testLex "return \n 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
-        testLex "return //hello"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
-        testLex "return /*hello*/"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
-        testLex "return //hello\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
-        testLex "return /*hello*/\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
-        testLex "return /*hello 1*/\n"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken]"
+        it "return mixed with comments" $ do
+            alexTestLex "return 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
+            alexTestLex "return \n 1"  `shouldBe` "[ReturnToken,WsToken,DecimalToken 1]"
+            alexTestLex "return //hello"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
+            alexTestLex "return /*hello*/"  `shouldBe` "[ReturnToken,WsToken,CommentToken]"
+            alexTestLex "return //hello\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
+            alexTestLex "return /*hello*/\n 1"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken,DecimalToken 1]"
+            alexTestLex "return /*hello 1*/\n"  `shouldBe` "[ReturnToken,WsToken,CommentToken,WsToken]"
 
-    it "numbers" $ do
-        testLex "123"       `shouldBe` "[DecimalToken 123]"
-        testLex "037"       `shouldBe` "[OctalToken 037]"
-        testLex "0xab"      `shouldBe` "[HexIntegerToken 0xab]"
-        testLex "0xCD"      `shouldBe` "[HexIntegerToken 0xCD]"
+        it "numbers" $ do
+            alexTestLex "123"       `shouldBe` "[DecimalToken 123]"
+            alexTestLex "037"       `shouldBe` "[OctalToken 037]"
+            alexTestLex "0xab"      `shouldBe` "[HexIntegerToken 0xab]"
+            alexTestLex "0xCD"      `shouldBe` "[HexIntegerToken 0xCD]"
 
-    it "invalid numbers" $ do
-        testLex "089"       `shouldBe` "[DecimalToken 0,DecimalToken 89]"
-        testLex "0xGh"      `shouldBe` "[DecimalToken 0,IdentifierToken 'xGx']"
+        it "invalid numbers" $ do
+            alexTestLex "089"       `shouldBe` "[DecimalToken 0,DecimalToken 89]"
+            alexTestLex "0xGh"      `shouldBe` "[DecimalToken 0,IdentifierToken 'xGx']"
 
-    it "string" $ do
-        testLex "'cat'"     `shouldBe` "[StringToken 'cat']"
-        testLex "\"dog\""   `shouldBe` "[StringToken \"dog\"]"
+        it "string" $ do
+            alexTestLex "'cat'"     `shouldBe` "[StringToken 'cat']"
+            alexTestLex "\"dog\""   `shouldBe` "[StringToken \"dog\"]"
 
-    it "strings with escape chars" $ do
-        testLex "'\t'"      `shouldBe` "[StringToken '\t']"
-        testLex "'\\n'"     `shouldBe` "[StringToken '\\n']"
-        testLex "'\\\\n'"   `shouldBe` "[StringToken '\\\\n']"
-        testLex "'\\\\'"    `shouldBe` "[StringToken '\\\\']"
-        testLex "'\\0'"     `shouldBe` "[StringToken '\\0']"
-        testLex "'\\12'"    `shouldBe` "[StringToken '\\12']"
-        testLex "'\\s'"      `shouldBe` "[StringToken '\\s']"
-        testLex "'\\-'"      `shouldBe` "[StringToken '\\-']"
+        it "strings with escape chars" $ do
+            alexTestLex "'\t'"      `shouldBe` "[StringToken '\t']"
+            alexTestLex "'\\n'"     `shouldBe` "[StringToken '\\n']"
+            alexTestLex "'\\\\n'"   `shouldBe` "[StringToken '\\\\n']"
+            alexTestLex "'\\\\'"    `shouldBe` "[StringToken '\\\\']"
+            alexTestLex "'\\0'"     `shouldBe` "[StringToken '\\0']"
+            alexTestLex "'\\12'"    `shouldBe` "[StringToken '\\12']"
+            alexTestLex "'\\s'"      `shouldBe` "[StringToken '\\s']"
+            alexTestLex "'\\-'"      `shouldBe` "[StringToken '\\-']"
 
-    it "strings with non-escaped chars" $
-        testLex "'\\/'"     `shouldBe` "[StringToken '\\/']"
+        it "strings with non-escaped chars" $
+            alexTestLex "'\\/'"     `shouldBe` "[StringToken '\\/']"
 
-    it "strings with escaped quotes" $ do
-        testLex "'\"'"      `shouldBe` "[StringToken '\"']"
-        testLex "\"\\\"\""  `shouldBe` "[StringToken \"\\\\\"\"]"
-        testLex "'\\\''"    `shouldBe` "[StringToken '\\\\'']"
-        testLex "'\"'"      `shouldBe` "[StringToken '\"']"
-        testLex "\"\\'\""      `shouldBe` "[StringToken \"\\'\"]"
+        it "strings with escaped quotes" $ do
+            alexTestLex "'\"'"      `shouldBe` "[StringToken '\"']"
+            alexTestLex "\"\\\"\""  `shouldBe` "[StringToken \"\\\\\"\"]"
+            alexTestLex "'\\\''"    `shouldBe` "[StringToken '\\\\'']"
+            alexTestLex "'\"'"      `shouldBe` "[StringToken '\"']"
+            alexTestLex "\"\\'\""      `shouldBe` "[StringToken \"\\'\"]"
 
-    it "spread token" $ do
-        testLex "...a" `shouldBe` "[SpreadToken,IdentifierToken 'a']"
+        it "spread token" $ do
+            alexTestLex "...a" `shouldBe` "[SpreadToken,IdentifierToken 'a']"
 
-    it "assignment" $ do
-        testLex "x=1"       `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
-        testLex "x=1\ny=2"  `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1,WsToken,IdentifierToken 'y',SimpleAssignToken,DecimalToken 2]"
+        it "assignment" $ do
+            alexTestLex "x=1"       `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            alexTestLex "x=1\ny=2"  `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1,WsToken,IdentifierToken 'y',SimpleAssignToken,DecimalToken 2]"
 
-    it "break/continue/return" $ do
-        testLex "break\nx=1"     `shouldBe` "[BreakToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
-        testLex "continue\nx=1"  `shouldBe` "[ContinueToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
-        testLex "return\nx=1"    `shouldBe` "[ReturnToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+        it "break/continue/return" $ do
+            alexTestLex "break\nx=1"     `shouldBe` "[BreakToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            alexTestLex "continue\nx=1"  `shouldBe` "[ContinueToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            alexTestLex "return\nx=1"    `shouldBe` "[ReturnToken,WsToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
 
-    it "var/let" $ do
-        testLex "var\n"     `shouldBe` "[VarToken,WsToken]"
-        testLex "let\n"     `shouldBe` "[LetToken,WsToken]"
+        it "var/let" $ do
+            alexTestLex "var\n"     `shouldBe` "[VarToken,WsToken]"
+            alexTestLex "let\n"     `shouldBe` "[LetToken,WsToken]"
 
-    it "in/of" $ do
-        testLex "in\n"     `shouldBe` "[InToken,WsToken]"
-        testLex "of\n"     `shouldBe` "[OfToken,WsToken]"
+        it "in/of" $ do
+            alexTestLex "in\n"     `shouldBe` "[InToken,WsToken]"
+            alexTestLex "of\n"     `shouldBe` "[OfToken,WsToken]"
 
-    it "function" $ do
-        testLex "async function\n"     `shouldBe` "[AsyncToken,WsToken,FunctionToken,WsToken]"
+        it "function" $ do
+            alexTestLex "async function\n"     `shouldBe` "[AsyncToken,WsToken,FunctionToken,WsToken]"
 
 
-testLex :: String -> String
-testLex str =
-    either id stringify $ alexTestTokeniser str
+    describe "with Happy rules" $ do
+        it "comments" $ do
+            happyTestLex "// 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 "    `shouldBe` "[]"
+            happyTestLex "/* 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 */"  `shouldBe` "[]"
+            happyTestLex "/* 𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡 */ // foo"  `shouldBe` "[]"
+
+        it "return that doesn't produce autosemi" $ do
+            happyTestLex "return 1"  `shouldBe` "[ReturnToken,DecimalToken 1]"
+            happyTestLex "return //hello"  `shouldBe` "[ReturnToken]"
+            happyTestLex "return/*hello*/1"  `shouldBe` "[ReturnToken,DecimalToken 1]"
+
+        it "return mixed with newlines that produce autosemi" $ do
+            happyTestLex "return \n 1"  `shouldBe` "[ReturnToken,AutoSemiToken,DecimalToken 1]"
+
+        it "return mixed with comments that produce autosemi and trailing expressions" $ do
+            happyTestLex "return /*hello \n */"  `shouldBe` "[ReturnToken,AutoSemiToken]"
+            happyTestLex "return /*hello \n 1*/"  `shouldBe` "[ReturnToken,AutoSemiToken]"
+            happyTestLex "return //hello\n"  `shouldBe` "[ReturnToken,AutoSemiToken]"
+
+        it "return mixed with comments that produce autosemi but no trailing expressions" $ do
+            happyTestLex "return //hello\n 1"  `shouldBe` "[ReturnToken,AutoSemiToken,DecimalToken 1]"
+            happyTestLex "return /*hello*/\n 1"  `shouldBe` "[ReturnToken,AutoSemiToken,DecimalToken 1]"
+            happyTestLex "return//hello\n1"  `shouldBe` "[ReturnToken,AutoSemiToken,DecimalToken 1]"
+
+        it "numbers" $ do
+            happyTestLex "123"       `shouldBe` "[DecimalToken 123]"
+            happyTestLex "037"       `shouldBe` "[OctalToken 037]"
+            happyTestLex "0xab"      `shouldBe` "[HexIntegerToken 0xab]"
+            happyTestLex "0xCD"      `shouldBe` "[HexIntegerToken 0xCD]"
+
+        it "invalid numbers" $ do
+            happyTestLex "089"       `shouldBe` "[DecimalToken 0,DecimalToken 89]"
+            happyTestLex "0xGh"      `shouldBe` "[DecimalToken 0,IdentifierToken 'xGx']"
+
+        it "string" $ do
+            happyTestLex "'cat'"     `shouldBe` "[StringToken 'cat']"
+            happyTestLex "\"dog\""   `shouldBe` "[StringToken \"dog\"]"
+
+        it "strings with escape chars" $ do
+            happyTestLex "'\t'"      `shouldBe` "[StringToken '\t']"
+            happyTestLex "'\\n'"     `shouldBe` "[StringToken '\\n']"
+            happyTestLex "'\\\\n'"   `shouldBe` "[StringToken '\\\\n']"
+            happyTestLex "'\\\\'"    `shouldBe` "[StringToken '\\\\']"
+            happyTestLex "'\\0'"     `shouldBe` "[StringToken '\\0']"
+            happyTestLex "'\\12'"    `shouldBe` "[StringToken '\\12']"
+            happyTestLex "'\\s'"      `shouldBe` "[StringToken '\\s']"
+            happyTestLex "'\\-'"      `shouldBe` "[StringToken '\\-']"
+
+        it "strings with non-escaped chars" $
+            happyTestLex "'\\/'"     `shouldBe` "[StringToken '\\/']"
+
+        it "strings with escaped quotes" $ do
+            happyTestLex "'\"'"      `shouldBe` "[StringToken '\"']"
+            happyTestLex "\"\\\"\""  `shouldBe` "[StringToken \"\\\\\"\"]"
+            happyTestLex "'\\\''"    `shouldBe` "[StringToken '\\\\'']"
+            happyTestLex "'\"'"      `shouldBe` "[StringToken '\"']"
+            happyTestLex "\"\\'\""      `shouldBe` "[StringToken \"\\'\"]"
+
+        it "spread token" $ do
+            happyTestLex "...a" `shouldBe` "[SpreadToken,IdentifierToken 'a']"
+
+        it "assignment" $ do
+            happyTestLex "x=1"       `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            happyTestLex "x=1\ny=2"  `shouldBe` "[IdentifierToken 'x',SimpleAssignToken,DecimalToken 1,IdentifierToken 'y',SimpleAssignToken,DecimalToken 2]"
+
+        it "break/continue/return" $ do
+            happyTestLex "break\nx=1"     `shouldBe` "[BreakToken,AutoSemiToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            happyTestLex "continue\nx=1"  `shouldBe` "[ContinueToken,AutoSemiToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+            happyTestLex "return\nx=1"    `shouldBe` "[ReturnToken,AutoSemiToken,IdentifierToken 'x',SimpleAssignToken,DecimalToken 1]"
+
+        it "var/let" $ do
+            happyTestLex "var\n"     `shouldBe` "[VarToken]"
+            happyTestLex "let\n"     `shouldBe` "[LetToken]"
+
+        it "in/of" $ do
+            happyTestLex "in\n"     `shouldBe` "[InToken]"
+            happyTestLex "of\n"     `shouldBe` "[OfToken]"
+
+        it "function" $ do
+            happyTestLex "async function\n"     `shouldBe` "[AsyncToken,FunctionToken]"
+
+
+
+alexTestLex :: String -> String
+alexTestLex = genericTestLex alexTestTokeniser
+
+happyTestLex :: String -> String
+happyTestLex = genericTestLex happyTestTokeniser
+
+genericTestLex :: (String -> Either String [Token]) -> String -> String
+genericTestLex lexer str =
+    either id stringify $ lexer str
   where
     stringify xs = "[" ++ intercalate "," (map showToken xs) ++ "]"
 

--- a/test/Test/Language/Javascript/ProgramParser.hs
+++ b/test/Test/Language/Javascript/ProgramParser.hs
@@ -18,11 +18,23 @@ testProgramParser = describe "Program parser:" $ do
     it "function" $ do
         testProg "function a(){}"     `shouldBe` "Right (JSAstProgram [JSFunction 'a' () (JSBlock [])])"
         testProg "function a(b,c){}"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [])])"
+
     it "comments" $ do
         testProg "//blah\nx=1;//foo\na"   `shouldBe` "Right (JSAstProgram [JSOpAssign ('=',JSIdentifier 'x',JSDecimal '1'),JSSemicolon,JSIdentifier 'a'])"
         testProg "/*x=1\ny=2\n*/z=2;//foo\na"  `shouldBe` "Right (JSAstProgram [JSOpAssign ('=',JSIdentifier 'z',JSDecimal '2'),JSSemicolon,JSIdentifier 'a'])"
         testProg "/* */\nfunction f() {\n/*  */\n}\n" `shouldBe` "Right (JSAstProgram [JSFunction 'f' () (JSBlock [])])"
         testProg "/* **/\nfunction f() {\n/*  */\n}\n" `shouldBe` "Right (JSAstProgram [JSFunction 'f' () (JSBlock [])])"
+
+    it "function with comments" $ do
+        testProg "function a(){/* return */}"     `shouldBe` "Right (JSAstProgram [JSFunction 'a' () (JSBlock [])])"
+        testProg "function a(b,c/*d*/){}"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [])])"
+
+    it "return with comments" $ do
+        testProg "function a(b,c){ return \n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
+        testProg "function a(b,c){ return // 4\n }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ])])"
+        testProg "function a(b,c){ return /* 4*/\n }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ])])"
+        testProg "function a(b,c){ return //\n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
+        testProg "function a(b,c){ return /*\n*/ 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
 
     it "if" $ do
         testProg "if(x);x=1"        `shouldBe` "Right (JSAstProgram [JSIf (JSIdentifier 'x') (JSEmptyStatement),JSOpAssign ('=',JSIdentifier 'x',JSDecimal '1')])"

--- a/test/Test/Language/Javascript/ProgramParser.hs
+++ b/test/Test/Language/Javascript/ProgramParser.hs
@@ -33,8 +33,14 @@ testProgramParser = describe "Program parser:" $ do
         testProg "function a(b,c){ return \n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
         testProg "function a(b,c){ return // 4\n }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ])])"
         testProg "function a(b,c){ return /* 4*/\n }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ])])"
+
+    it "return with comments and trailing expression" $ do
         testProg "function a(b,c){ return //\n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
         testProg "function a(b,c){ return /*\n*/ 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
+
+    it "return without spaces and but comments and trailing expression" $ do
+        testProg "function a(b,c){ return//\n4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
+        testProg "function a(b,c){ return/*\n*/4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'a' (JSIdentifier 'b',JSIdentifier 'c') (JSBlock [JSReturn ,JSDecimal '4'])])"
 
     it "if" $ do
         testProg "if(x);x=1"        `shouldBe` "Right (JSAstProgram [JSIf (JSIdentifier 'x') (JSEmptyStatement),JSOpAssign ('=',JSIdentifier 'x',JSDecimal '1')])"
@@ -103,4 +109,3 @@ testProg str = showStrippedMaybe (parseUsing parseProgram str "src")
 
 testFileUtf8 :: FilePath -> IO String
 testFileUtf8 fileName = showStripped <$> parseFileUtf8 fileName
-

--- a/test/Test/Language/Javascript/RoundTrip.hs
+++ b/test/Test/Language/Javascript/RoundTrip.hs
@@ -136,6 +136,9 @@ testRoundTrip = describe "Roundtrip:" $ do
         testRT "var [x, y]=z;"
         testRT "let {x: [y]}=z;"
         testRT "let yield=1"
+        testRT "return x"
+        testRT "return /**/ x"
+        testRT "return /*\n*/ x"
 
     it "module" $ do
         testRTModule "import  def  from 'mod'"


### PR DESCRIPTION
Hi! Currently, there is a subtle difference in the way `language-javascript` deals with auto semicolons when comments are present.

Let's have a look at this code sample:

```javascript
function f1() {
  return // hello
    4
}

function f2() {
  return /* hello */
    4
}


function f3() {
  return /* hello
    */ 4
}

function f4() {
  return
    4
}
```

And how [esprima](https://esprima.org/index.html) parses it:


```json
{
  "type": "Program",
  "body": [
    {
      "type": "FunctionDeclaration",
      "id": {
        "type": "Identifier",
        "name": "f1"
      },
      "params": [],
      "body": {
        "type": "BlockStatement",
        "body": [
          {
            "type": "ReturnStatement",
            "argument": null
          },
          {
            "type": "ExpressionStatement",
            "expression": {
              "type": "Literal",
              "value": 4,
              "raw": "4"
            }
          }
        ]
      },
      "generator": false,
      "expression": false,
      "async": false
    },
    {
      "type": "FunctionDeclaration",
      "id": {
        "type": "Identifier",
        "name": "f2"
      },
      "params": [],
      "body": {
        "type": "BlockStatement",
        "body": [
          {
            "type": "ReturnStatement",
            "argument": null
          },
          {
            "type": "ExpressionStatement",
            "expression": {
              "type": "Literal",
              "value": 4,
              "raw": "4"
            }
          }
        ]
      },
      "generator": false,
      "expression": false,
      "async": false
    },
    {
      "type": "FunctionDeclaration",
      "id": {
        "type": "Identifier",
        "name": "f3"
      },
      "params": [],
      "body": {
        "type": "BlockStatement",
        "body": [
          {
            "type": "ReturnStatement",
            "argument": null
          },
          {
            "type": "ExpressionStatement",
            "expression": {
              "type": "Literal",
              "value": 4,
              "raw": "4"
            }
          }
        ]
      },
      "generator": false,
      "expression": false,
      "async": false
    },
    {
      "type": "FunctionDeclaration",
      "id": {
        "type": "Identifier",
        "name": "f4"
      },
      "params": [],
      "body": {
        "type": "BlockStatement",
        "body": [
          {
            "type": "ReturnStatement",
            "argument": null
          },
          {
            "type": "ExpressionStatement",
            "expression": {
              "type": "Literal",
              "value": 4,
              "raw": "4"
            }
          }
        ]
      },
      "generator": false,
      "expression": false,
      "async": false
    }
  ],
  "sourceType": "script"
}
```

As you can see, the parser is introducing an automatic semicolon in all the four scenarios. This behavior is consistent with modern V8 and SpiderMonkey engines.


However, let's have a look at how `language-javascript` handles these scenarios. If you add the following tests to `ProgramParser.hs`...

```haskell
describe "function with autosemi on return" $ do
  it "return with inline comment" $ do
      testProg "function f1(){ return //hello\n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'f1' () (JSBlock [JSReturn ,JSDecimal '4'])])"

  it "return with multiline comment" $ do
      testProg "function f2(){ return /* hello */\n  4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'f2' () (JSBlock [JSReturn ,JSDecimal '4'])])"

  it "return with multiline comment with newline" $ do
      testProg "function f3(){ return /* hello\n  */ 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'f3' () (JSBlock [JSReturn ,JSDecimal '4'])])"

  it "return with newline" $ do
      testProg "function f4(){ return \n 4 }"  `shouldBe` "Right (JSAstProgram [JSFunction 'f4' () (JSBlock [JSReturn ,JSDecimal '4'])])"
```

...only the fourth and last test will actually produce the expected results. The other three will fail with the same error:

```
  test/Test/Language/Javascript/ProgramParser.hs:29:13:
  1) Program parser:, function with autosemi on return, return with inline comment
      expected: "Right (JSAstProgram [JSFunction 'f1' () (JSBlock [JSReturn ,JSDecimal '4'])])"
        but got: "Right (JSAstProgram [JSFunction 'f1' () (JSBlock [JSReturn JSDecimal '4' ])])"

  To rerun use: --match "/Program parser:/function with autosemi on return/return with inline comment/"

  test/Test/Language/Javascript/ProgramParser.hs:32:13:
  2) Program parser:, function with autosemi on return, return with multiline comment
      expected: "Right (JSAstProgram [JSFunction 'f2' () (JSBlock [JSReturn ,JSDecimal '4'])])"
        but got: "Right (JSAstProgram [JSFunction 'f2' () (JSBlock [JSReturn JSDecimal '4' ])])"

  To rerun use: --match "/Program parser:/function with autosemi on return/return with multiline comment/"

  test/Test/Language/Javascript/ProgramParser.hs:35:13:
  3) Program parser:, function with autosemi on return, return with multiline comment with newline
      expected: "Right (JSAstProgram [JSFunction 'f3' () (JSBlock [JSReturn ,JSDecimal '4'])])"
        but got: "Right (JSAstProgram [JSFunction 'f3' () (JSBlock [JSReturn JSDecimal '4' ])])"

  To rerun use: --match "/Program parser:/function with autosemi on return/return with multiline comment with newline/"
```

In other words, this parser is only inserting an automatic semicolon after a newline, but not after comments. This PR fixes this issue. 

I have also refactored the `Lexer` tests, so that they don't just inspect the tokens produced by `alex`, but also those sent to `happy`.  