### PR TITLE
Remove dependency on utf8-light.

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -71,7 +71,6 @@ Test-Suite testsuite
                  , QuickCheck >= 2
                  , hspec
                  , array            >= 0.3
-                 , utf8-light       >= 0.4
                  , containers       >= 0.2
                  , mtl              >= 1.1
                  , utf8-string      >= 0.3.7 && < 2


### PR DESCRIPTION
It doesn't look like we need that package. Tested without that dependency on ghc 9.2.